### PR TITLE
[bug out] Add crash handling to zipcode lookup

### DIFF
--- a/server.js
+++ b/server.js
@@ -37,32 +37,37 @@ app.post('/getReps', function(req, res){
     console.log(req.body.zipcode);
     var zip = req.body.zipcode; //front end request should be in the format {zipcode: zipcode}
     request('https://congress.api.sunlightfoundation.com/legislators/locate?zip=' + zip + '&apikey=fca53d5418a64a6a81b29bb71c97b9a1', function(error, response, data){
-        data = JSON.parse(data);
-        var obj = {};
-        obj.reps = [];
-        for(var i = 0; i < data.results.length; i++){
-            var package = {};
-            var person = data.results[i];
-            package.bioguide_id = person.bioguide_id;
-            package.name = person.first_name + " " + person.last_name;
-            package.title = person.title === "Sen" ?  "Senator" : "Representative";
-            package.district = person.district;
-            package.email = person.oc_email;
-            package.twitter = person.twitter_id;
-            package.website = person.website;
-            if(person.party === "R"){
-                package.affiliation = "Republican";
+        if (!data.includes('<')) {
+            data = JSON.parse(data);
+            var obj = {};
+            obj.reps = [];
+            for(var i = 0; i < data.results.length; i++){
+                var package = {};
+                var person = data.results[i];
+                package.bioguide_id = person.bioguide_id;
+                package.name = person.first_name + " " + person.last_name;
+                package.title = person.title === "Sen" ?  "Senator" : "Representative";
+                package.district = person.district;
+                package.email = person.oc_email;
+                package.twitter = person.twitter_id;
+                package.website = person.website;
+                if(person.party === "R"){
+                    package.affiliation = "Republican";
+                }
+                else if (person.party === "D"){
+                    package.affiliation = "Democrat";
+                }
+                else{
+                    package.affiliation = "Independent";
+                }
+                obj.reps.push(package);
             }
-            else if (person.party === "D"){
-                package.affiliation = "Democrat";
-            }
-            else{
-                package.affiliation = "Independent";
-            }
-            obj.reps.push(package);
+            console.log(obj);
+            res.send(obj);
+        } else {
+            console.log('There was a problem with the data provider.');
+            res.sendStatus(500);
         }
-        console.log(obj);
-        res.send(obj);
     });
 });
 


### PR DESCRIPTION
This is a relatively essential one. This patch keeps things online after a bad response. The server returns XML in massive swaths at times and every crash makes other testing fail. We may need to consider an alternate API that only needs to return bioguides for zip lookup as we transition to the database. Alternately, we may want to consider a separate, on-system zipcode lookup table. There would only be 49000 records.