### PR TITLE
[feature] Add provisional bill listing to state rep profile

### DIFF
--- a/client/app/billsummary/bill-summary.html
+++ b/client/app/billsummary/bill-summary.html
@@ -2,7 +2,7 @@
 
   <div class="title-bar" style="height: 35px">
     <div class="left">
-		<div class="head" data-ng-click="goHome()"><img src="images/fox-orange.svg" width="18px"> Foxcove</div>
+		<div class="head link" data-ng-click="goHome()"><img src="images/fox-orange.svg" width="18px"> Foxcove</div>
     </div>
     <div class="right">
         <input type="text" placeholder="try another ZIP" class="large-4 medium-5 small-6 columns graff" style="float: right; margin-top: 15px; height: 24px; font-size: 85%" data-ng-model="location" data-ng-pattern="/^\d{5}$/" data-ng-controller="HomeController" data-ng-enter="submit()">

--- a/client/app/helpers/directives.js
+++ b/client/app/helpers/directives.js
@@ -11,4 +11,16 @@ angular.module('app.directives', [])
       }
     });
   };
+})
+
+.directive('ngImgErr', function() {
+  return {
+    link: function(scope, element, attrs) {
+      element.bind('error', function() {
+        if (attrs.src !== attrs.ngImgSrc) {
+          attrs.$set('src', attrs.ngImgErr);
+        }
+      });
+    }
+  }
 });

--- a/client/app/helpers/factories.js
+++ b/client/app/helpers/factories.js
@@ -55,6 +55,7 @@ angular.module('app.helperFactories', [])
     return $http.post('/getStateRep', leg_id)
       .then(function (response) {
         repObject.data = response.data;
+        repObject.data.party = repObject.data.party.replace('Democratic', 'Democrat');
         return response.data;
       }, function (error) {
         console.log(error);

--- a/client/app/helpers/factories.js
+++ b/client/app/helpers/factories.js
@@ -62,9 +62,21 @@ angular.module('app.helperFactories', [])
       });
   }
 
+  function getStateRepBills(leg_id) {
+    return $http.post('/getStateRepBills', leg_id)
+      .then(function(response) {
+        repObject.bills = response.data;
+        console.log(repObject.bills);
+        return response.data;
+      }, function(error) {
+        console.log(error);
+      });
+  }
+
   return {
-    repObject: repObject.data,
-    getRepFromLegId: getRepFromLegId
+    repObject: repObject,
+    getRepFromLegId: getRepFromLegId,
+    getStateRepBills: getStateRepBills
   };
 })
 .factory('RepBio', function($http) {

--- a/client/app/helpers/factories.js
+++ b/client/app/helpers/factories.js
@@ -66,7 +66,7 @@ angular.module('app.helperFactories', [])
     return $http.post('/getStateRepBills', leg_id)
       .then(function(response) {
         repObject.bills = response.data;
-        console.log(repObject.bills);
+        // TODO: Slice bill title into subject and description.
         return response.data;
       }, function(error) {
         console.log(error);

--- a/client/app/local-results/local-results-view.html
+++ b/client/app/local-results/local-results-view.html
@@ -27,7 +27,7 @@
         </ul>
       </p>
     </div>
-    <div class="medium-6 columns medium-pull-6" data-ng-if="stateLegs">
+    <div class="medium-6 columns medium-pull-6" data-ng-if="stateLegs.length > 0">
       <h3 class="head">Your {{state}} Legislators</h3>
       <ul class="row small-up-3 rep-cols">
         <li class="column grid-list" data-ng-repeat="leg in stateLegs">

--- a/client/app/local-results/local-results-view.html
+++ b/client/app/local-results/local-results-view.html
@@ -2,7 +2,7 @@
 
   <div class="title-bar" style="height: 35px">
     <div class="left">
-      <div class="head" data-ng-click="goHome()"><img src="images/fox-orange.svg" width="18px"> Foxcove</div>
+      <div class="head link" data-ng-click="goHome()"><img src="images/fox-orange.svg" width="18px"> Foxcove</div>
     </div>
     <div class="right">
         <input type="text" placeholder="try another ZIP" class="large-4 medium-5 small-6 columns graff" style="float: right; margin-top: 15px; height: 24px; font-size: 85%" data-ng-model="location" data-ng-pattern="/^\d{5}$/" data-ng-controller="HomeController" data-ng-enter="submit()">

--- a/client/app/local-results/local-results-view.html
+++ b/client/app/local-results/local-results-view.html
@@ -32,7 +32,7 @@
       <ul class="row small-up-3 rep-cols">
         <li class="column grid-list" data-ng-repeat="leg in stateLegs">
           <span data-tooltip aria-haspopup="true" class="has-tip" tabindex="1" title="{{leg.title}} {{leg.full_name}} ({{leg.party}})">
-            <span class="matrix-resize matrix-square {{leg.party}} matrix" style="background-image: url({{leg.photo_url || null}})" alt="{{leg.full_name}}" data-ng-click="loadProfile(leg)">
+            <span class="matrix-resize matrix-square {{leg.party}} matrix" style="background-image: url({{leg.photo_url}})" alt="{{leg.full_name}}" data-ng-click="loadProfile(leg)">
               <!--This State Legislator profile adaptation isn't in place yet, but when it is it will work the exact same as the federal-->
               <span class="secondary badge down"><img data-ng-src="images/{{leg.party}}.svg" width="16px"></span>
             </span>

--- a/client/app/person-profile/person-profile-controller.js
+++ b/client/app/person-profile/person-profile-controller.js
@@ -4,7 +4,7 @@ angular.module('app.personProfile',[])
 
   $scope.build = function() {
     var person = $state.params;
-    if (person.leg_id) {
+    if (person.leg_id && person.leg_id.match(/\w{1,3}\d{6}/) !== null) {
       StateRepProfile.getRepFromLegId(person)
         .then(function(results) {
           $scope.rep = results;

--- a/client/app/person-profile/person-profile-controller.js
+++ b/client/app/person-profile/person-profile-controller.js
@@ -12,7 +12,7 @@ angular.module('app.personProfile',[])
           $scope.rep.firstname = results.first_name;
           $scope.rep.lastname = results.last_name;
           $scope.getBio($scope.rep);
-          // $scope.getBills($scope.rep); << Retool for state
+          $scope.getStateRepBills(person);
         });
     } else if (person.bioguide_id && person.bioguide_id.match(/\w{1}\d{6}/) !== null) {
       RepProfile.getRepFromBioId(person)
@@ -53,6 +53,16 @@ angular.module('app.personProfile',[])
         }
       });
   };
+  $scope.getStateRepBills = function(rep) {
+    StateRepProfile.getStateRepBills(rep)
+      .then(function(results) {
+        if (results) {
+          $scope.bills = results;
+        } else {
+          $scope.bills = ['Sorry, no records of sponsored bills available.'];
+        }
+    });
+  }
   $scope.loadBill = function (bill) {
     bill = JSON.parse(bill);
     // CACHE selected bill

--- a/client/app/person-profile/person-profile-view.html
+++ b/client/app/person-profile/person-profile-view.html
@@ -27,12 +27,12 @@
             <div class="small-12 columns">
               <label>Sponsored Bills
                 <select name="billSelect" ng-model="model.bill">
-                  <option ng-repeat="bill in bills | orderBy: '-last_action_at'" value="{{bill}}">{{ bill.popular_title || bill.short_title || bill.official_title }}</option>
+                  <option ng-repeat="bill in bills | orderBy: '-last_action_at' || '-created_at'" value="{{bill}}">{{ bill.popular_title || bill.short_title || bill.official_title || bill.title }}</option>
                 </select>
               </label>
             </div>
             <div class="small-12 columns">
-              <button type="submit" class="success small hollow button" ng-click="loadBill(model.bill)" data-ng-if="model">Learn More About This Bill</button>
+              <button type="submit" class="success small hollow button" ng-click="loadBill(model.bill)" data-ng-if="model && rep.title">Learn More About This Bill</button>
             </div>
           </div>
         </form>

--- a/client/app/person-profile/person-profile-view.html
+++ b/client/app/person-profile/person-profile-view.html
@@ -2,7 +2,7 @@
   <!-- Navigation -->
   <div class="title-bar" style="height: 35px">
     <div class="left">
-      <div class="head" data-ng-click="goHome()"><img src="images/fox-orange.svg" width="18px"> Foxcove</div>
+      <div class="head link" data-ng-click="goHome()"><img src="images/fox-orange.svg" width="18px"> Foxcove</div>
     </div>
     <div class="right">
         <input type="text" placeholder="try another ZIP" class="large-4 medium-5 small-6 columns graff" style="float: right; margin-top: 15px; height: 24px; font-size: 75%" data-ng-model="location" data-ng-pattern="/^\d{5}$/" data-ng-controller="HomeController" data-ng-enter="submit()">

--- a/client/app/person-profile/person-profile-view.html
+++ b/client/app/person-profile/person-profile-view.html
@@ -15,7 +15,7 @@
   <div class="row">
 
     <div class="large-3 medium-3 columns">
-      <img data-ng-src="{{rep.img}}" alt="{{rep.firstname}} {{rep.lastname}}">
+      <img data-ng-src="{{rep.img}}" data-ng-img-err="images/{{rep.party}}.svg" alt="{{rep.firstname}} {{rep.lastname}}">
     </div>
 
     <div class="medium-7 large-6 columns">

--- a/server.js
+++ b/server.js
@@ -60,15 +60,15 @@ app.post('/getReps', function(req, res){
 });
 
 app.post('/getRep', function(req, res) {
-  getRep(req.body.bioguide_id, res, function(data) {
-    res.send(data);
-  });
+  getRep(req.body.bioguide_id, res, res.send.bind(res));
 });
 
 app.post('/getStateRep', function(req, res) {
-  getStateRep(req.body.leg_id, res, function(data) {
-    res.send(data);
-  });
+  getStateRep.rep(req.body.leg_id, res, res.send.bind(res));
+});
+
+app.post('/getStateRepBills', function(req, res) {
+  getStateRep.bills(req.body.leg_id, res, res.send.bind(res));
 });
 
 app.post('/getBio', function(req, res) {

--- a/server/modules/get-state-rep.js
+++ b/server/modules/get-state-rep.js
@@ -1,10 +1,34 @@
 var https = require('https');
 
-module.exports = function(req, res, cb) {
+// Retrieve State Rep Detail
+
+module.exports.rep = function(req, res, cb) {
   var leg_id = req;
   https.get({
     hostname: 'openstates.org',
     path: '/api/v1/legislators/' + leg_id + '/?apikey=' + process.env.SUNLIGHT_API
+  }, function(res) {
+    var body = '';
+    res.on('data', function(chunk) {
+      body += chunk;
+    }).on('end', function(err) {
+      if (body) {
+        cb(body);
+      } else {
+        console.log('Something went wrong.', err);
+        return false;
+      }
+    });
+  });
+};
+
+// Retrieve Bills Sponsored By Rep
+
+module.exports.bills = function(req, res, cb) {
+  var leg_id = req;
+  https.get({
+    hostname: 'openstates.org',
+    path: '/api/v1/bills/?sponsor_id=' + leg_id + '&apikey=' + process.env.SUNLIGHT_API
   }, function(res) {
     var body = '';
     res.on('data', function(chunk) {


### PR DESCRIPTION
Turns out state bills have neither immediately accessible links or descriptions. What they do have is incredibly verbose titles. This functionality currently lists all the bills. The next step is dissecting the title into a subject and description and saving the description for the bill summary page.